### PR TITLE
Adjusts to change in blog plugin using primary instead of secondary tabs for fields

### DIFF
--- a/Plugin.php
+++ b/Plugin.php
@@ -274,7 +274,7 @@ class Plugin extends PluginBase
 
             $categoriesConfig = $this->transformPostCategoriesIntoTaglist($form, $tab);
 
-            $form->addSecondaryTabFields([
+            $form->addTabFields([
                 'categories' => $categoriesConfig,
                 'tags' => [
                     'label' => self::LOCALIZATION_KEY . 'form.tags.label',
@@ -431,7 +431,7 @@ class Plugin extends PluginBase
     {
         $tab = self::LOCALIZATION_KEY . 'navigation.tab.type';
 
-        $form->addSecondaryTabFields([
+        $form->addTabFields([
             'post_type' => [
                 'label' => self::LOCALIZATION_KEY . 'form.post_types.label',
                 'tab' => $tab,
@@ -528,7 +528,7 @@ class Plugin extends PluginBase
             }
         }
 
-        $form->addSecondaryTabFields([
+        $form->addTabFields([
             PostType::TABLE_NAME . '_attributes' => $typeAttributes
         ]);
     }


### PR DESCRIPTION
Lately the blog plugin got an update which moved all blog post fields into the primary tabs. To prevent cluttering the Backend UI blog taxonomy plugin should also move things into the primary tabs instead. See https://github.com/wintercms/wn-blog-plugin/commit/0411ac74570e744e4b989c22d19c3f250e9b92b8

Changes proposed in this pull request:

- move fields into primary tabs

@GinoPane
